### PR TITLE
Explain `grunt.option` bug with boolean command-line flags

### DIFF
--- a/grunt.option.md
+++ b/grunt.option.md
@@ -39,6 +39,8 @@ grunt.registerTask('deploy', ['validate', 'upload']);
 
 _Note that boolean options can be specified using just a key without a value. For example, running `grunt deploy --staging` on the command line would cause `grunt.option('staging')` to return `true`._
 
+_There is a bug preventing boolean options from working correctly in 0.4.5.  You can only have a single boolean option, and it must be specified last on the command-line.  This bug will be fixed in Grunt 0.5.0._
+
 
 ### grunt.option ☃
 Gets or sets an option.


### PR DESCRIPTION
I've updated the documentation for grunt.options to explain that boolean flags do not work correctly.  (gruntjs/grunt#908 and gruntjs/grunt#603)

If appropriate, I can further update this PR to include a link to the relevant issues and/or a more thorough explanation of grunt 0.4.5's actual behavior regarding command-line options.

I would also like to link to @Coridyn's [nopt-grunt-fix](https://github.com/widgetworks/nopt-grunt-fix), which easily fixes this issue for people who don't want to wait for grunt 0..5.0.
